### PR TITLE
feat(storage): Firestore adapter skeleton, InMemory adapter, tests and docs

### DIFF
--- a/docs/SPRINT-1.md
+++ b/docs/SPRINT-1.md
@@ -12,5 +12,8 @@
 ## Tests
 - `tests/schemas.spec.ts` valida que los fixtures pasan los esquemas.
 
+## Firestore (SPRINT 1.2)
+- Ver `docs/firestore.md` para el esquema propuesto (colecciones, índices, TTL y buenas prácticas).
+
 ## Próximo
 - Integración Firestore (colecciones y reglas de indexado).

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -1,0 +1,26 @@
+# Firestore — Esquema propuesto (SPRINT 1.2)
+
+Colección raíz: `users/{userId}`
+
+Subcolecciones y docs:
+- `rules/{ruleId}`: Regla de limpieza.
+  - Índice: orderBy(`priority` asc)
+- `whitelist/{entryId}`: Lista blanca.
+- `config/labelMapping` (doc único): IDs de etiquetas Gmail (`review`, `archive`, `junk`).
+- `candidates/{messageId}`: Candidatos detectados para limpiar.
+  - Opcional TTL: campo `ttlAt` (timestamp) para expirar candidatos antiguos.
+- `auditLogs/{autoId}`: Historial de acciones.
+  - Índice: orderBy(`timestamp` desc)
+
+Campos (resumen):
+- Rule: `id`, `type`, `params`, `enabled`, `priority`, `createdAt`.
+- WhitelistEntry: `id`, `userId`, `senderOrDomain`, `createdAt`.
+- LabelMapping: `userId`, `labels.{review,archive,junk}`.
+- MessageCandidate: `messageId`, `signals.*`, `appliedRuleId?`, `proposedAction`.
+- AuditLog: `messageId`, `action`, `ruleId?`, `timestamp`.
+
+Buenas prácticas:
+- Minimizar datos: no guardar contenidos, solo metadatos.
+- Cifrado: usar CMEK si aplica; evitar datos sensibles.
+- Retención: TTL en `candidates` y políticas de borrado para `auditLogs` si se requiere.
+- Seguridad: reglas restringidas por `userId`; el backend valida el sujeto OAuth.

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@google-cloud/firestore": "^7.11.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"
   }

--- a/src/storage/FirestoreStorage.ts
+++ b/src/storage/FirestoreStorage.ts
@@ -1,0 +1,60 @@
+import { Firestore } from '@google-cloud/firestore';
+import type { Storage } from './Storage';
+import type { Rule } from '../models/Rule';
+import type { WhitelistEntry } from '../models/Lists';
+import type { LabelMapping } from '../models/LabelMapping';
+import type { AuditLog } from '../models/AuditLog';
+import type { MessageCandidate } from '../models/MessageCandidate';
+
+export class FirestoreStorage implements Storage {
+  constructor(private db: Firestore) {}
+
+  private userDoc(userId: string) {
+    return this.db.collection('users').doc(userId);
+  }
+
+  async putRule(userId: string, rule: Rule): Promise<void> {
+    await this.userDoc(userId).collection('rules').doc(rule.id).set(rule, { merge: true });
+  }
+
+  async listRules(userId: string): Promise<Rule[]> {
+    const snap = await this.userDoc(userId).collection('rules').orderBy('priority', 'asc').get();
+    return snap.docs.map((d) => d.data() as Rule);
+  }
+
+  async upsertWhitelistEntry(userId: string, entry: WhitelistEntry): Promise<void> {
+    await this.userDoc(userId).collection('whitelist').doc(entry.id).set(entry, { merge: true });
+  }
+
+  async listWhitelist(userId: string): Promise<WhitelistEntry[]> {
+    const snap = await this.userDoc(userId).collection('whitelist').get();
+    return snap.docs.map((d) => d.data() as WhitelistEntry);
+  }
+
+  async setLabelMapping(userId: string, mapping: LabelMapping): Promise<void> {
+    await this.userDoc(userId).collection('config').doc('labelMapping').set(mapping);
+  }
+
+  async getLabelMapping(userId: string): Promise<LabelMapping | null> {
+    const doc = await this.userDoc(userId).collection('config').doc('labelMapping').get();
+    return doc.exists ? (doc.data() as LabelMapping) : null;
+  }
+
+  async putMessageCandidate(userId: string, candidate: MessageCandidate): Promise<void> {
+    await this.userDoc(userId).collection('candidates').doc(candidate.messageId).set(candidate, { merge: true });
+  }
+
+  async listMessageCandidates(userId: string, limit = 50): Promise<MessageCandidate[]> {
+    const snap = await this.userDoc(userId).collection('candidates').limit(limit).get();
+    return snap.docs.map((d) => d.data() as MessageCandidate);
+  }
+
+  async addAuditLog(userId: string, log: AuditLog): Promise<void> {
+    await this.userDoc(userId).collection('auditLogs').add(log);
+  }
+
+  async listAuditLogs(userId: string, limit = 100): Promise<AuditLog[]> {
+    const snap = await this.userDoc(userId).collection('auditLogs').orderBy('timestamp', 'desc').limit(limit).get();
+    return snap.docs.map((d) => d.data() as AuditLog);
+  }
+}

--- a/src/storage/InMemoryStorage.ts
+++ b/src/storage/InMemoryStorage.ts
@@ -1,0 +1,68 @@
+import type { Storage } from './Storage';
+import type { Rule } from '../models/Rule';
+import type { WhitelistEntry } from '../models/Lists';
+import type { LabelMapping } from '../models/LabelMapping';
+import type { AuditLog } from '../models/AuditLog';
+import type { MessageCandidate } from '../models/MessageCandidate';
+
+export class InMemoryStorage implements Storage {
+  private rules = new Map<string, Map<string, Rule>>();
+  private whitelist = new Map<string, Map<string, WhitelistEntry>>();
+  private labelMappings = new Map<string, LabelMapping>();
+  private candidates = new Map<string, Map<string, MessageCandidate>>();
+  private auditLogs = new Map<string, AuditLog[]>();
+
+  async putRule(userId: string, rule: Rule): Promise<void> {
+    const m = this.rules.get(userId) ?? new Map<string, Rule>();
+    m.set(rule.id, rule);
+    this.rules.set(userId, m);
+  }
+
+  async listRules(userId: string): Promise<Rule[]> {
+    const m = this.rules.get(userId);
+    return m ? Array.from(m.values()).sort((a, b) => a.priority - b.priority) : [];
+  }
+
+  async upsertWhitelistEntry(userId: string, entry: WhitelistEntry): Promise<void> {
+    const m = this.whitelist.get(userId) ?? new Map<string, WhitelistEntry>();
+    m.set(entry.id, entry);
+    this.whitelist.set(userId, m);
+  }
+
+  async listWhitelist(userId: string): Promise<WhitelistEntry[]> {
+    const m = this.whitelist.get(userId);
+    return m ? Array.from(m.values()) : [];
+  }
+
+  async setLabelMapping(userId: string, mapping: LabelMapping): Promise<void> {
+    this.labelMappings.set(userId, mapping);
+  }
+
+  async getLabelMapping(userId: string): Promise<LabelMapping | null> {
+    return this.labelMappings.get(userId) ?? null;
+  }
+
+  async putMessageCandidate(userId: string, candidate: MessageCandidate): Promise<void> {
+    const m = this.candidates.get(userId) ?? new Map<string, MessageCandidate>();
+    m.set(candidate.messageId, candidate);
+    this.candidates.set(userId, m);
+  }
+
+  async listMessageCandidates(userId: string, limit = 50): Promise<MessageCandidate[]> {
+    const m = this.candidates.get(userId);
+    const arr = m ? Array.from(m.values()) : [];
+    return arr.slice(0, limit);
+  }
+
+  async addAuditLog(userId: string, log: AuditLog): Promise<void> {
+    const arr = this.auditLogs.get(userId) ?? [];
+    arr.push(log);
+    this.auditLogs.set(userId, arr);
+  }
+
+  async listAuditLogs(userId: string, limit = 100): Promise<AuditLog[]> {
+    const arr = this.auditLogs.get(userId) ?? [];
+    const copy = [...arr].reverse();
+    return copy.slice(0, limit);
+  }
+}

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -1,0 +1,22 @@
+import type { Rule } from '../models/Rule';
+import type { WhitelistEntry } from '../models/Lists';
+import type { LabelMapping } from '../models/LabelMapping';
+import type { AuditLog } from '../models/AuditLog';
+import type { MessageCandidate } from '../models/MessageCandidate';
+
+export interface Storage {
+  putRule(userId: string, rule: Rule): Promise<void>;
+  listRules(userId: string): Promise<Rule[]>;
+
+  upsertWhitelistEntry(userId: string, entry: WhitelistEntry): Promise<void>;
+  listWhitelist(userId: string): Promise<WhitelistEntry[]>;
+
+  setLabelMapping(userId: string, mapping: LabelMapping): Promise<void>;
+  getLabelMapping(userId: string): Promise<LabelMapping | null>;
+
+  putMessageCandidate(userId: string, candidate: MessageCandidate): Promise<void>;
+  listMessageCandidates(userId: string, limit?: number): Promise<MessageCandidate[]>;
+
+  addAuditLog(userId: string, log: AuditLog): Promise<void>;
+  listAuditLogs(userId: string, limit?: number): Promise<AuditLog[]>;
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,3 @@
+export * from './Storage';
+export * from './InMemoryStorage';
+export * from './FirestoreStorage';

--- a/tests/storage.inmemory.spec.ts
+++ b/tests/storage.inmemory.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryStorage } from '../src/storage/InMemoryStorage';
+import type { Rule } from '../src/models/Rule';
+
+const userId = 'u1';
+
+describe('InMemoryStorage', () => {
+  it('stores and lists rules ordered by priority', async () => {
+    const s = new InMemoryStorage();
+    const r1: Rule = { id: 'r1', type: 'keyword', params: { k: 'a' }, enabled: true, priority: 20, createdAt: '2025-01-01T00:00:00Z' };
+    const r2: Rule = { id: 'r2', type: 'list_unsubscribe', params: {}, enabled: true, priority: 10, createdAt: '2025-01-02T00:00:00Z' };
+    await s.putRule(userId, r1);
+    await s.putRule(userId, r2);
+    const list = await s.listRules(userId);
+    expect(list.map(r => r.id)).toEqual(['r2', 'r1']);
+  });
+
+  it('handles whitelist upsert/list', async () => {
+    const s = new InMemoryStorage();
+    await s.upsertWhitelistEntry(userId, { id: 'w1', userId, senderOrDomain: 'example.com', createdAt: '2025-01-01T00:00:00Z' });
+    const wl = await s.listWhitelist(userId);
+    expect(wl.length).toBe(1);
+    expect(wl[0].senderOrDomain).toBe('example.com');
+  });
+
+  it('sets and gets label mapping', async () => {
+    const s = new InMemoryStorage();
+    await s.setLabelMapping(userId, { userId, labels: { review: 'L1', archive: 'L2', junk: 'L3' } });
+    const lm = await s.getLabelMapping(userId);
+    expect(lm?.labels.junk).toBe('L3');
+  });
+
+  it('stores and lists message candidates', async () => {
+    const s = new InMemoryStorage();
+    await s.putMessageCandidate(userId, { messageId: 'm1', signals: { from: 'a@b.com' }, proposedAction: 'archive' });
+    await s.putMessageCandidate(userId, { messageId: 'm2', signals: { from: 'c@d.com' }, proposedAction: 'label_review' });
+    const list = await s.listMessageCandidates(userId, 1);
+    expect(list.length).toBe(1);
+    expect(['m1','m2']).toContain(list[0].messageId);
+  });
+
+  it('adds and lists audit logs newest first', async () => {
+    const s = new InMemoryStorage();
+    await s.addAuditLog(userId, { messageId: 'm1', action: 'archive', timestamp: '2025-01-03T00:00:00Z' });
+    await s.addAuditLog(userId, { messageId: 'm2', action: 'move_to_spam', timestamp: '2025-01-04T00:00:00Z' });
+    const logs = await s.listAuditLogs(userId, 10);
+    expect(logs[0].messageId).toBe('m2');
+    expect(logs[1].messageId).toBe('m1');
+  });
+});


### PR DESCRIPTION
Este PR implementa SPRINT 1.2:

- Storage
  - InMemoryStorage (completo) y tests (`tests/storage.inmemory.spec.ts`).
  - FirestoreStorage (esqueleto) con colecciones y consultas básicas.
- Documentación
  - `docs/firestore.md` con esquema propuesto de colecciones/índices/TTL y buenas prácticas.
  - `docs/SPRINT-1.md` actualizado enlazando la doc de Firestore.
- Dependencias
  - Añadido `@google-cloud/firestore` y `@types/node`.

Notas:
- Los tests usan solo InMemoryStorage (no requiere credenciales).
- Para integrar Firestore real se usará ADC (GOOGLE_APPLICATION_CREDENTIALS) o emulador.

Siguientes pasos (SPRINT 1.3):
- Adapter del emulador Firestore para integración local.
- Validar reglas e índices.
