### PR TITLE
feat(storage): StorageFactory, env docs and tests (SPRINT 1.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# cdspam environment example
+# Select storage driver: inmemory | firestore
+STORAGE_DRIVER=inmemory
+
+# Firestore project id (required if STORAGE_DRIVER=firestore)
+FIRESTORE_PROJECT_ID=your-gcp-project-id
+
+# Path to your GCP service account key (JSON) if using ADC via file
+# On Windows use an absolute path like C:\\path\\to\\service-account.json
+GOOGLE_APPLICATION_CREDENTIALS=
+
+# Firestore emulator (optional). If set, SDK uses the emulator instead of prod.
+# Example: localhost:8080
+FIRESTORE_EMULATOR_HOST=

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,16 @@
+# Configuración de entorno
+
+## Variables
+- `STORAGE_DRIVER`: `inmemory` (por defecto) o `firestore`.
+- `FIRESTORE_PROJECT_ID`: requerido si usas Firestore real.
+- `GOOGLE_APPLICATION_CREDENTIALS`: ruta a credencial de cuenta de servicio (JSON) para ADC.
+- `FIRESTORE_EMULATOR_HOST`: host del emulador (p.ej. `localhost:8080`). Si está definida, el SDK usa el emulador.
+
+## Opciones de autenticación
+- Emulador Firestore: no requiere login; arranca el emulador y define `FIRESTORE_EMULATOR_HOST`.
+- Producción GCP:
+  - Opción A: credencial de servicio (recomendada en backend). Asigna roles mínimos (Firestore User/Viewer segun operación). Exporta `GOOGLE_APPLICATION_CREDENTIALS` apuntando al JSON.
+  - Opción B: `gcloud auth application-default login` en entorno de desarrollo.
+
+## Ejemplos (.env)
+Consulta `.env.example` y copia a `.env` ajustando valores.

--- a/src/storage/StorageFactory.ts
+++ b/src/storage/StorageFactory.ts
@@ -1,0 +1,24 @@
+import { InMemoryStorage } from './InMemoryStorage';
+import { FirestoreStorage } from './FirestoreStorage';
+import type { Storage } from './Storage';
+import { Firestore } from '@google-cloud/firestore';
+
+export interface StorageOptions {
+  driver?: 'inmemory' | 'firestore';
+  projectId?: string;
+}
+
+export function createStorage(opts: StorageOptions = {}): Storage {
+  const driver = opts.driver || (process.env.STORAGE_DRIVER as 'inmemory' | 'firestore') || 'inmemory';
+
+  if (driver === 'firestore') {
+    const projectId = opts.projectId || process.env.FIRESTORE_PROJECT_ID;
+    if (!projectId) {
+      throw new Error('FIRESTORE_PROJECT_ID es requerido para usar Firestore');
+    }
+    const db = new Firestore({ projectId });
+    return new FirestoreStorage(db);
+  }
+
+  return new InMemoryStorage();
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,3 +1,4 @@
 export * from './Storage';
 export * from './InMemoryStorage';
 export * from './FirestoreStorage';
+export * from './StorageFactory';

--- a/tests/storage.factory.spec.ts
+++ b/tests/storage.factory.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createStorage } from '../src/storage/StorageFactory';
+import { InMemoryStorage } from '../src/storage/InMemoryStorage';
+
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...OLD_ENV };
+});
+
+afterEach(() => {
+  process.env = OLD_ENV;
+});
+
+describe('StorageFactory', () => {
+  it('returns InMemoryStorage by default', () => {
+    delete process.env.STORAGE_DRIVER;
+    const s = createStorage();
+    expect(s).toBeInstanceOf(InMemoryStorage);
+  });
+
+  it('returns InMemoryStorage when driver=inmemory', () => {
+    process.env.STORAGE_DRIVER = 'inmemory';
+    const s = createStorage();
+    expect(s).toBeInstanceOf(InMemoryStorage);
+  });
+});


### PR DESCRIPTION
Este PR completa SPRINT 1.3:

- StorageFactory para seleccionar driver por env (`inmemory` por defecto o `firestore`).
- `.env.example` y `docs/env.md` con configuración y opciones de autenticación/Emulador.
- Tests `tests/storage.factory.spec.ts`.

Siguientes pasos (SPRINT 1.4):
- Integrar Firestore Emulator en CI/local y pruebas de integración del adapter.
